### PR TITLE
Add Mnemonic::from_entropy and Mnemonic::from_entropy_hex

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,9 @@
 error_chain! {
     foreign_links {
         EntropyUnavailable(::std::io::Error);
+        DataDecode(::data_encoding::decode::Error);
     }
+
     errors {
         InvalidChecksum {
             description("invalid checksum")


### PR DESCRIPTION
This is the opposite of `get_entropy` and `get_entropy_hex`, it's needed if you want to go from the entropy to the mnemonic.

I noticed there was some related discussion in #5, so I'm not sure if that was ever resolved.