### PR TITLE
Performance and Rust idiomatic improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/lib.rs"
 [dependencies]
 error-chain ="^0.11.0"
 bitreader = "^0.3.0"
-bit-vec = "^0.4.3"
 ring = "^0.12"
 rand = "^0.3.15"
 data-encoding = "^2.0"

--- a/benches/validate.rs
+++ b/benches/validate.rs
@@ -1,0 +1,17 @@
+#![feature(test)]
+
+extern crate test;
+extern crate bip39;
+
+use test::Bencher;
+
+use bip39::{Mnemonic, Language};
+
+#[bench]
+fn parse_to_ast(b: &mut Bencher) {
+    let phrase = "silly laptop awake length nature thunder category claim reveal supply attitude drip";
+
+    b.iter(|| {
+        let _ = Mnemonic::validate(phrase, Language::English);
+    });
+}

--- a/benches/validate.rs
+++ b/benches/validate.rs
@@ -5,13 +5,20 @@ extern crate bip39;
 
 use test::Bencher;
 
-use bip39::{Mnemonic, Language};
+use bip39::{Mnemonic, MnemonicType, Language};
 
 #[bench]
-fn parse_to_ast(b: &mut Bencher) {
+fn validate(b: &mut Bencher) {
     let phrase = "silly laptop awake length nature thunder category claim reveal supply attitude drip";
 
     b.iter(|| {
         let _ = Mnemonic::validate(phrase, Language::English);
     });
+}
+
+#[bench]
+fn new_mnemonic(b: &mut Bencher) {
+    b.iter(|| {
+        let _ = Mnemonic::new(MnemonicType::Type12Words, Language::English, "");
+    })
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -6,13 +6,13 @@
 //!
 
 
-use ring::digest::{self, digest};
+use ring::digest::{self, digest, Digest};
 use ring::pbkdf2;
 
 extern crate rand;
 use self::rand::{OsRng, Rng};
 
-use ::error::Error;
+use ::error::Result;
 
 static PBKDF2_ROUNDS: u32 = 2048;
 static PBKDF2_BYTES: usize = 64;
@@ -20,21 +20,19 @@ static PBKDF2_BYTES: usize = 64;
 
 /// SHA256 helper function, internal to the crate
 ///
-pub(crate) fn sha256(input: &[u8]) -> Vec<u8> {
+pub(crate) fn sha256(input: &[u8]) -> Digest {
 
     static DIGEST_ALG: &'static digest::Algorithm = &digest::SHA256;
 
-    let hash = digest(DIGEST_ALG, input);
-
-    hash.as_ref().to_vec()
+    digest(DIGEST_ALG, input)
 }
 
 /// Random byte generator, used to create new mnemonics
 ///
-pub(crate) fn gen_random_bytes(byte_length: usize) -> Result<Vec<u8>, Error> {
+pub(crate) fn gen_random_bytes(byte_length: usize) -> Result<Vec<u8>> {
 
     let mut rng = OsRng::new()?;
-    let entropy = rng.gen_iter::<u8>().take(byte_length).collect::<Vec<u8>>();
+    let entropy = rng.gen_iter().take(byte_length).collect();
 
     Ok(entropy)
 }
@@ -43,9 +41,8 @@ pub(crate) fn gen_random_bytes(byte_length: usize) -> Result<Vec<u8>, Error> {
 ///
 /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
 /// [Seed]: ../seed/struct.Seed.html
-/// 
-pub(crate) fn pbkdf2(input: &[u8],
-              salt: String) -> Vec<u8> {
+///
+pub(crate) fn pbkdf2(input: &[u8], salt: &str) -> Vec<u8> {
 
     let mut seed = vec![0u8; PBKDF2_BYTES];
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -65,10 +65,10 @@ impl Language {
     }
 
     /// Get the word list for this language
-    pub fn get_wordlist(&self) -> &'static Vec<&'static str> {
+    pub fn get_wordlist(&self) -> &'static [&'static str] {
 
         match *self {
-            Language::English => &lazy::VEC_BIP39_WORDLIST_ENGLISH
+            Language::English => &*lazy::VEC_BIP39_WORDLIST_ENGLISH
         }
     }
 
@@ -82,7 +82,7 @@ impl Language {
     pub fn get_wordmap(&self) -> &'static HashMap<&'static str, u16> {
 
         match *self {
-            Language::English => &lazy::HASHMAP_BIP39_WORDMAP_ENGLISH
+            Language::English => &*lazy::HASHMAP_BIP39_WORDMAP_ENGLISH
         }
     }
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,37 +1,30 @@
-use ::error::{Error, ErrorKind};
+use ::error::{ErrorKind, Result};
 use std::collections::HashMap;
 
 mod lazy {
-	use std::collections::HashMap;
-	
-	/// lazy generation of the word list
-	fn gen_wordlist(lang_words: &str) -> Vec<String> {
+    use super::HashMap;
 
-		lang_words.split_whitespace()
-			.map(|s| s.into())
-			.collect()
-	}
+    /// lazy generation of the word list
+    fn gen_wordlist(lang_words: &str) -> Vec<&str> {
+        lang_words.split_whitespace().collect()
+    }
 
-	/// lazy generation of the word map
-	fn gen_wordmap(word_list: &Vec<String>) -> HashMap<String, u16> {
+    /// lazy generation of the word map
+    fn gen_wordmap(wordlist: &[&'static str]) -> HashMap<&'static str, u16> {
+        wordlist
+            .iter()
+            .enumerate()
+            .map(|(i, item)| (*item, i as u16))
+            .collect()
+    }
 
-		let mut word_map: HashMap<String, u16> = HashMap::new();
-		for (i, item) in word_list.into_iter().enumerate() {
-			word_map.insert(item.to_owned(), i as u16);
-		}
+    static BIP39_WORDLIST_ENGLISH: &str = include_str!("bip39_english.txt");
 
-		word_map
-	}
+    lazy_static! {
+        pub static ref VEC_BIP39_WORDLIST_ENGLISH: Vec<&'static str> = gen_wordlist(BIP39_WORDLIST_ENGLISH);
 
-	static BIP39_WORDLIST_ENGLISH: &'static str = include_str!("bip39_english.txt"); 
-
-	lazy_static! {
-		pub static ref VEC_BIP39_WORDLIST_ENGLISH: Vec<String> = { gen_wordlist(BIP39_WORDLIST_ENGLISH) };
-	}
-
-	lazy_static! {
-		pub static ref HASHMAP_BIP39_WORDMAP_ENGLISH: HashMap<String, u16> = { gen_wordmap(&VEC_BIP39_WORDLIST_ENGLISH) };
-	}
+        pub static ref HASHMAP_BIP39_WORDMAP_ENGLISH: HashMap<&'static str, u16> = gen_wordmap(&VEC_BIP39_WORDLIST_ENGLISH);
+    }
 }
 
 /// The language determines which words will be used in a mnemonic phrase, but also indirectly
@@ -60,45 +53,42 @@ impl Language {
     ///
     /// ```
     /// [Language]: ../language/struct.Language.html
-	pub fn for_locale<S>(locale: S) -> Result<Language, Error> where S: Into<String> {
-
-        let l = locale.into();
-
-        let lang = match &*l {
+    pub fn for_locale(locale: &str) -> Result<Language> {
+        let lang = match locale {
             "en_US.UTF-8" => Language::English,
             "en_GB.UTF-8" => Language::English,
 
-            _ => { return Err(ErrorKind::LanguageUnavailable.into()) }
+            _ => bail!(ErrorKind::LanguageUnavailable)
         };
 
         Ok(lang)
     }
 
-	/// Get the word list for this language
-    pub fn get_wordlist(&self) -> &'static Vec<String> {
+    /// Get the word list for this language
+    pub fn get_wordlist(&self) -> &'static Vec<&'static str> {
 
-		match *self {
+        match *self {
             Language::English => &lazy::VEC_BIP39_WORDLIST_ENGLISH
         }
-	}
+    }
 
-	/// Get a [`HashMap`][HashMap] that allows word -> index lookups in the word list
-	///
-	/// The index of an individual word in the word list is used as the binary value of that word
-	/// when the phrase is turned into a [`Seed`][Seed].
-	///
-	/// [HashMap]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
-	/// [Seed]: ../seed/struct.Seed.html
-	pub fn get_wordmap(&self) -> &'static HashMap<String, u16> {
+    /// Get a [`HashMap`][HashMap] that allows word -> index lookups in the word list
+    ///
+    /// The index of an individual word in the word list is used as the binary value of that word
+    /// when the phrase is turned into a [`Seed`][Seed].
+    ///
+    /// [HashMap]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+    /// [Seed]: ../seed/struct.Seed.html
+    pub fn get_wordmap(&self) -> &'static HashMap<&'static str, u16> {
 
-		match *self {
+        match *self {
             Language::English => &lazy::HASHMAP_BIP39_WORDMAP_ENGLISH
         }
-	}
+    }
 }
 
 impl Default for Language {
-	fn default() -> Language {
-		Language::English
-	}
+    fn default() -> Language {
+        Language::English
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 #[macro_use] extern crate lazy_static;
 extern crate data_encoding;
 extern crate bitreader;
-extern crate bit_vec;
 extern crate ring;
 
 mod mnemonic;

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -36,7 +36,7 @@ use ::seed::Seed;
 ///
 #[derive(Debug, Clone)]
 pub struct Mnemonic {
-    string: String,
+    phrase: String,
     seed: Seed,
     lang: Language,
     entropy: Vec<u8>,
@@ -177,25 +177,25 @@ impl Mnemonic {
     /// ```
     ///
     /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
-    pub fn from_string<S>(string: S,
+    pub fn from_string<S>(phrase: S,
                           lang: Language,
                           password: S) -> Result<Mnemonic> where S: Into<String> {
 
-        let m = string.into();
-        let p = password.into();
+        let phrase = phrase.into();
+        let password = password.into();
 
         // this also validates the checksum and phrase length before returning the entropy so we
         // can store it. We don't use the validate function here to avoid having a public API that
         // takes a phrase string and returns the entropy directly. See the Mnemonic::entropy()
         // docs for the reason.
-        let entropy = Mnemonic::entropy(&m, lang)?;
-        let seed = Seed::generate(&m.as_bytes(), &p);
+        let entropy = Mnemonic::entropy(&phrase, lang)?;
+        let seed = Seed::generate(phrase.as_bytes(), &password);
 
         let mnemonic = Mnemonic {
-            string: m,
-            seed: seed,
-            lang: lang,
-            entropy: entropy
+            phrase,
+            seed,
+            lang,
+            entropy,
         };
 
         Ok(mnemonic)
@@ -224,8 +224,8 @@ impl Mnemonic {
     /// ```
     ///
     /// [Mnemonic::from_string()]: ../mnemonic/struct.Mnemonic.html#method.from_string
-    pub fn validate(string: &str, lang: Language) -> Result<()> {
-        Mnemonic::entropy(string, lang).map(|_| ())
+    pub fn validate(phrase: &str, lang: Language) -> Result<()> {
+        Mnemonic::entropy(phrase, lang).map(|_| ())
     }
 
     /// Calculate the checksum, verify it and return the entropy
@@ -291,14 +291,14 @@ impl Mnemonic {
 
     /// Get the mnemonic phrase as a string reference
     pub fn as_str(&self) -> &str {
-        &self.string
+        &self.phrase
     }
 
     /// Get the mnemonic phrase as an owned string
     ///
     /// Note: this clones the internal Mnemonic String instance
     pub fn get_string(&self) -> String {
-        self.string.clone()
+        self.phrase.clone()
     }
 
     /// Get the [`Language`][Language]

--- a/src/mnemonic_type.rs
+++ b/src/mnemonic_type.rs
@@ -1,4 +1,4 @@
-use ::error::{Error, ErrorKind};
+use ::error::{ErrorKind, Result};
 use std::fmt;
 
 /// Determines the number of words that will be present in a [`Mnemonic`][Mnemonic] phrase
@@ -48,15 +48,14 @@ impl MnemonicType {
     ///
     /// let mnemonic_type = MnemonicType::for_word_count(12).unwrap();
     /// ```
-    pub fn for_word_count(size: usize) -> Result<MnemonicType, Error> {
-
+    pub fn for_word_count(size: usize) -> Result<MnemonicType> {
         let mnemonic_type = match size {
             12 => MnemonicType::Type12Words,
             15 => MnemonicType::Type15Words,
             18 => MnemonicType::Type18Words,
             21 => MnemonicType::Type21Words,
             24 => MnemonicType::Type24Words,
-            _ => { return Err(ErrorKind::InvalidWordLength.into()) }
+            _ => bail!(ErrorKind::InvalidWordLength)
         };
 
         Ok(mnemonic_type)
@@ -73,15 +72,14 @@ impl MnemonicType {
     ///
     /// let mnemonic_type = MnemonicType::for_key_size(128).unwrap();
     /// ```
-    pub fn for_key_size(size: usize) -> Result<MnemonicType, Error> {
-
+    pub fn for_key_size(size: usize) -> Result<MnemonicType> {
         let mnemonic_type = match size {
             128 => MnemonicType::Type12Words,
             160 => MnemonicType::Type15Words,
             192 => MnemonicType::Type18Words,
             224 => MnemonicType::Type21Words,
             256 => MnemonicType::Type24Words,
-            _ => { return Err(ErrorKind::InvalidKeysize.into()) }
+            _ => bail!(ErrorKind::InvalidKeysize)
         };
 
         Ok(mnemonic_type)
@@ -108,22 +106,10 @@ impl MnemonicType {
     /// ```
     ///
     /// [MnemonicType::entropy_bits()]: ../mnemonic_type/struct.MnemonicType.html#method.entropy_bits
-    pub fn for_phrase<S>(phrase: S) -> Result<MnemonicType, Error> where S: Into<String> {
+    pub fn for_phrase(phrase: &str) -> Result<MnemonicType> {
+        let word_count = phrase.split(" ").count();
 
-        let m = phrase.into();
-
-        let v: Vec<&str> = m.split(" ").into_iter().collect();
-
-        let mnemonic_type = match v.len() {
-            12 => MnemonicType::Type12Words,
-            15 => MnemonicType::Type15Words,
-            18 => MnemonicType::Type18Words,
-            21 => MnemonicType::Type21Words,
-            24 => MnemonicType::Type24Words,
-            _ => { return Err(ErrorKind::InvalidWordLength.into()) }
-        };
-
-        Ok(mnemonic_type)
+        Self::for_word_count(word_count)
     }
 
     /// Return the number of entropy+checksum bits
@@ -140,16 +126,13 @@ impl MnemonicType {
     /// let total_bits = mnemonic_type.total_bits();
     /// ```
     pub fn total_bits(&self) -> usize {
-
-        let total_bits: usize = match *self {
+        match *self {
             MnemonicType::Type12Words => 132,
             MnemonicType::Type15Words => 165,
             MnemonicType::Type18Words => 198,
             MnemonicType::Type21Words => 231,
             MnemonicType::Type24Words => 264
-        };
-
-        total_bits
+        }
     }
 
     /// Return the number of entropy bits
@@ -166,16 +149,13 @@ impl MnemonicType {
     /// let entropy_bits = mnemonic_type.entropy_bits();
     /// ```
     pub fn entropy_bits(&self) -> usize {
-
-        let entropy_bits: usize = match *self {
+        match *self {
             MnemonicType::Type12Words => 128,
             MnemonicType::Type15Words => 160,
             MnemonicType::Type18Words => 192,
             MnemonicType::Type21Words => 224,
             MnemonicType::Type24Words => 256
-        };
-
-        entropy_bits
+        }
     }
 
     /// Return the number of checksum bits
@@ -192,16 +172,13 @@ impl MnemonicType {
     /// let checksum_bits = mnemonic_type.checksum_bits();
     /// ```
     pub fn checksum_bits(&self) -> usize {
-
-        let checksum_bits: usize = match *self {
+        match *self {
             MnemonicType::Type12Words => 4,
             MnemonicType::Type15Words => 5,
             MnemonicType::Type18Words => 6,
             MnemonicType::Type21Words => 7,
             MnemonicType::Type24Words => 8
-        };
-
-        checksum_bits
+        }
     }
 
     /// Return the number of words
@@ -216,16 +193,13 @@ impl MnemonicType {
     /// let word_count = mnemonic_type.word_count();
     /// ```
     pub fn word_count(&self) -> usize {
-
-        let word_count: usize = match *self {
+        match *self {
             MnemonicType::Type12Words => 12,
             MnemonicType::Type15Words => 15,
             MnemonicType::Type18Words => 18,
             MnemonicType::Type21Words => 21,
             MnemonicType::Type24Words => 24
-        };
-
-        word_count
+        }
     }
 }
 

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,4 +1,4 @@
-use ::crypto::{pbkdf2};
+use ::crypto::pbkdf2;
 
 use data_encoding::HEXUPPER;
 
@@ -26,7 +26,6 @@ use data_encoding::HEXUPPER;
 pub struct Seed {
     bytes: Vec<u8>,
     hex: String,
-
 }
 
 impl Seed {
@@ -35,12 +34,11 @@ impl Seed {
     ///
     /// Cannot be used outside the crate, in order to guarantee correctness
     /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
-    pub(crate) fn generate(entropy: &[u8],
-                           password: &str) -> Seed {
+    pub(crate) fn generate(entropy: &[u8], password: &str) -> Seed {
 
         let salt = format!("mnemonic{}", password);
-        let seed_value = pbkdf2(entropy, salt);
-        let hex = HEXUPPER.encode(seed_value.as_ref());
+        let seed_value = pbkdf2(entropy, &salt);
+        let hex = HEXUPPER.encode(&seed_value);
 
         Seed {
             bytes: seed_value,
@@ -83,7 +81,7 @@ impl AsRef<[u8]> for Seed {
 
 impl AsRef<str> for Seed {
     fn as_ref(&self) -> &str {
-        
+
         self.as_hex()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,60 @@
 
-pub(crate) fn bit_from_u16_as_u11(input: u16, position: u16) -> bool {
-    if position < 11 {
-        input & (1 << (10 - position)) != 0
-    } else {
-        false
+pub(crate) struct BitWriter {
+    offset: usize,
+    remainder: u32,
+    inner: Vec<u8>,
+}
+
+impl BitWriter {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut bytes = capacity / 8;
+
+        if capacity % 8 != 0 {
+            bytes += 1;
+        }
+
+        Self {
+            offset: 0,
+            remainder: 0,
+            inner: Vec::with_capacity(bytes)
+        }
     }
+
+    pub fn push(&mut self, source: u16, bits: usize) {
+        debug_assert!(bits > 0 && bits <= 16, "bits out of range");
+
+        let shift = 32 - bits;
+
+        self.remainder |= ((source as u32) << shift) >> self.offset;
+        self.offset += bits;
+
+        while self.offset >= 8 {
+            self.inner.push((self.remainder >> 24) as u8);
+            self.remainder <<= 8;
+            self.offset -= 8;
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len() * 8 + self.offset
+    }
+
+    pub fn into_bytes(mut self) -> Vec<u8> {
+        if self.offset != 0 {
+            self.inner.push((self.remainder >> 24) as u8);
+        }
+
+        self.inner
+    }
+}
+
+pub(crate) fn truncate(mut source: Vec<u8>, size: usize) -> Vec<u8> {
+    source.truncate(size);
+    source
+}
+
+pub(crate) fn checksum(source: u8, bits: usize) -> u8 {
+    debug_assert!(bits <= 8, "Can operate on 8-bit integers only");
+
+    source >> (8 - bits)
 }


### PR DESCRIPTION
+ Removed `bitvec` dependency, wrote a quick `BitWriter` struct that allows pushing 11 bits onto a `Vec<u8>` at once.
+ Removed a bunch of unnecessary allocations. This results in some (not all) functions that used to take generic `S: Into<String>` to take `&str`, which is more idiomatic although it is a breaking change on the API surface. Functions that need allocated strings (constructors that return owned structs mostly) remained unaffected.
+ `wordlist` and `wordmap` work using `&'static str` instead of `String`s to avoid unnecessary allocations (not very critical).
+ Replaced `Result<T, Error>` with custom `Result<T>` from `error_chain`.
+ Bunch of smaller idiomatic changes that I likely can't recall here.
+ Added benchmarks (`rustup run nightly cargo bench`). **Phrase validation time has been cut to nearly a quarter of original time.**